### PR TITLE
BugFix: Handling amount entered when creating a new expense

### DIFF
--- a/TravelExpenses/ViewControllers/CreateExpenseTableViewController.swift
+++ b/TravelExpenses/ViewControllers/CreateExpenseTableViewController.swift
@@ -146,8 +146,8 @@ class CreateExpenseTableViewController: FUIFormTableViewController {
                 // NOTE: hitting enter in field gives raw value, tabbing out of field gives formatted
                 if let value = numberFormatter.number(from: $0) {
                     self?.expense.amount = BigDecimal(value.decimalValue)
-                } else if let doubleValue = Double($0)  {
-                    self?.expense.amount = BigDecimal(Decimal(doubleValue))
+                } else if let value = BigDecimal.parse($0)  {
+                    self?.expense.amount = value
                 } else {
                     self?.expense.amount = BigDecimal(0)
                 }

--- a/TravelExpenses/ViewControllers/CreateExpenseTableViewController.swift
+++ b/TravelExpenses/ViewControllers/CreateExpenseTableViewController.swift
@@ -142,7 +142,15 @@ class CreateExpenseTableViewController: FUIFormTableViewController {
             cell.valueTextField.addDoneButtonToKeyboard()
 
             cell.onChangeHandler = { [weak self, weak cell] in
-                self?.expense.amount = BigDecimal.parse($0)
+                // The changed value may contain currency formatting, so handle both raw and formatted cases
+                // NOTE: hitting enter in field gives raw value, tabbing out of field gives formatted
+                if let value = numberFormatter.number(from: $0) {
+                    self?.expense.amount = BigDecimal(value.decimalValue)
+                } else if let doubleValue = Double($0)  {
+                    self?.expense.amount = BigDecimal(Decimal(doubleValue))
+                } else {
+                    self?.expense.amount = BigDecimal(0)
+                }
 
                 let validationMessage = self?.expense.validationMessage(for: \.amount)
                 cell?.validationMessage = validationMessage


### PR DESCRIPTION
## Context
During the SAP Cloud Platform SDK for iOS Workshop I noticed a bug in the sample code when entering new expenses. None of my new expenses had values after submitting.

## Issue
The problem is related to how changed values are passed to FUITitleFormCell in the onChangeHandler if formatting is used for the valueTextField text value for display. Depending on the timing of cell reload and whether the user uses the enter key or tab to move out of field, the change handler may get the raw or formatted version of the new value. The previous code assumed no formatting would ever get passed for the change value.

## Fix
The fix handles 3 possible scenarios:
- A formatted value using the same formatter as used for display
- A simple double value string (previous code case)
- No value, the user has cleared the field after previously setting value
