### PR TITLE
Remove unnecessary force-casts

### DIFF
--- a/TravelExpenses/ViewControllers/CreateExpenseTableViewController.swift
+++ b/TravelExpenses/ViewControllers/CreateExpenseTableViewController.swift
@@ -161,7 +161,7 @@ class CreateExpenseTableViewController: FUIFormTableViewController {
         // Setup editable `FUIListPickerFormCell` for Currency selection
         case (1, 0):
             let cell = tableView.dequeueReusableCell(withIdentifier: FUIListPickerFormCell.reuseIdentifier, for: indexPath) as! FUIListPickerFormCell
-            applyDefaultConfiguration(forListPickerFormCell: cell, dataSource: currencyPickerDataSource as! FUIListPickerDataSource)
+            applyDefaultConfiguration(forListPickerFormCell: cell, dataSource: currencyPickerDataSource)
 
             cell.keyName = "Currency"
 
@@ -190,7 +190,7 @@ class CreateExpenseTableViewController: FUIFormTableViewController {
         // Setup editable `FUIListPickerFormCell` for Expense Type selection
         case (1, 1):
             let cell = tableView.dequeueReusableCell(withIdentifier: FUIListPickerFormCell.reuseIdentifier, for: indexPath) as! FUIListPickerFormCell
-            applyDefaultConfiguration(forListPickerFormCell: cell, dataSource: expenseTypePickerDataSource as! FUIListPickerDataSource)
+            applyDefaultConfiguration(forListPickerFormCell: cell, dataSource: expenseTypePickerDataSource)
 
             cell.keyName = "Expense Type"
 


### PR DESCRIPTION
There were a couple of force-casts to a protocol that were causing build warnings because the types already conformed to that protocol. I've removed these, so we now have a completely clean build.